### PR TITLE
feat(contract): emit JSON payload with index + terms in request_resolve

### DIFF
--- a/agents/term-resolver/0.0.1/agent.py
+++ b/agents/term-resolver/0.0.1/agent.py
@@ -1,6 +1,8 @@
 from nearai.agents.environment import Environment
 import requests
 from serpapi_client import serpapi_search, SerpApiError
+import json
+import asyncio
 
 BET_TO_QUERY_PROMPT = """
 You are an assistant that converts a bet condition into a search query.
@@ -45,7 +47,7 @@ def run(env: Environment):
         env.add_reply("Sorry. Cannot give you access :)")
         return
 
-    # message = env.get_last_message()
+    message = env.get_last_message()
 
     try:
         resp = requests.get(

--- a/agents/term-resolver/0.0.1/metadata.json
+++ b/agents/term-resolver/0.0.1/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "term-resolver",
-  "version": "0.0.3",
+  "version": "0.0.10",
   "description": "This resolves terms on on-chain smart contracts",
   "category": "agent",
   "tags": [],

--- a/agents/term-resolver/0.0.1/metadata.json
+++ b/agents/term-resolver/0.0.1/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "term-resolver",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "This resolves terms on on-chain smart contracts",
   "category": "agent",
   "tags": [],

--- a/client/app/campaign/page.tsx
+++ b/client/app/campaign/page.tsx
@@ -39,12 +39,14 @@ export default function AICampaignPage() {
 
   const requestResolve = async (bet_id: number) => {
     setResolvingId(bet_id)
-    // const res: string = await viewFunction({
-    //   contractId: CONTRACT_ID,
-    //   method: "get_resolution",
-    //   args: { bet_id },
-    // });
-    const res = `Mock resolution for bet #${bet_id}` // stub
+    console.log(bet_id);
+    
+    const res = await callFunction({
+      contractId: CONTRACT_ID,
+      method: "request_resolve",
+      args: { index: (bet_id - 1) },
+    });
+
     setResolvingId(null)
   }
 

--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -3,9 +3,12 @@
 import "@near-wallet-selector/modal-ui/styles.css";
 import { WalletSelectorProvider } from "@near-wallet-selector/react-hook";
 import { setupMeteorWallet } from "@near-wallet-selector/meteor-wallet";
+import { NETWORK } from "@/lib/near/config";
+import { NetworkId } from "@near-wallet-selector/core";
+
 
 const walletSelectorConfig = {
-  network: "testnet" as const, // or process.env.NEXT_PUBLIC_NEAR_NETWORK
+  network: NETWORK as NetworkId, // or process.env.NEXT_PUBLIC_NEAR_NETWORK
   modules: [setupMeteorWallet()],
 };
 

--- a/client/lib/near/web3modal.ts
+++ b/client/lib/near/web3modal.ts
@@ -1,19 +1,19 @@
 import { reconnect } from '@wagmi/core';
 import { createAppKit } from '@reown/appkit/react'
-import { nearTestnet } from '@reown/appkit/networks'
+import { near, nearTestnet } from '@reown/appkit/networks'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 
 const projectId = '5bb0fe33763b3bea40b8d69e4269b4ae';
 
 export const wagmiAdapter = new WagmiAdapter({
   projectId,
-  networks: [nearTestnet],
+  networks: [near],
 });
 
 export const web3Modal = createAppKit({
   adapters: [wagmiAdapter],
   projectId,
-  networks: [nearTestnet],
+  networks: [near],
   enableWalletConnect: true,
   features: {
     analytics: true,

--- a/contracts/Deployments.md
+++ b/contracts/Deployments.md
@@ -2,7 +2,7 @@
 
 ### Create a new account
 ```bash
-ACCOUNT_NAME=test-campaign-6.testnet
+ACCOUNT_NAME=test-campaign-7.testnet
 near create-account $ACCOUNT_NAME  --useFaucet
 ```
 

--- a/contracts/Deployments.md
+++ b/contracts/Deployments.md
@@ -2,7 +2,7 @@
 
 ### Create a new account
 ```bash
-ACCOUNT_NAME=test-campaign-15.testnet
+ACCOUNT_NAME=test-campaign-16.testnet
 near create-account $ACCOUNT_NAME  --useFaucet
 ```
 

--- a/contracts/Deployments.md
+++ b/contracts/Deployments.md
@@ -2,7 +2,7 @@
 
 ### Create a new account
 ```bash
-ACCOUNT_NAME=test-campaign-8.testnet
+ACCOUNT_NAME=test-campaign-9.testnet
 near create-account $ACCOUNT_NAME  --useFaucet
 ```
 

--- a/contracts/Deployments.md
+++ b/contracts/Deployments.md
@@ -2,7 +2,7 @@
 
 ### Create a new account
 ```bash
-ACCOUNT_NAME=test-campaign-9.testnet
+ACCOUNT_NAME=test-campaign-15.testnet
 near create-account $ACCOUNT_NAME  --useFaucet
 ```
 
@@ -10,6 +10,12 @@ near create-account $ACCOUNT_NAME  --useFaucet
 
 ```bash
 near deploy $ACCOUNT_NAME  ./target/near/test_campaign.wasm
+```
+
+### Test
+
+```bash
+cargo test -- --nocapture
 ```
 
 ### Example logs for test-campaign
@@ -56,4 +62,8 @@ near deploy $ACCOUNT_NAME  ./target/near/test_campaign.wasm
     }
   ]
 }
+```
+
+```bash
+{"data":[{"agent":"ai-creator.near/term-resolver/latest","env_vars":null,"max_iterations":null,"message":"foo-term_0","referral_id":null,"request_id":null,"signer_id":"alice.near","thread_id":null}],"event":"run_agent","standard":"nearai","version":"0.1.19"}
 ```

--- a/contracts/Deployments.md
+++ b/contracts/Deployments.md
@@ -2,7 +2,7 @@
 
 ### Create a new account
 ```bash
-ACCOUNT_NAME=test-campaign-7.testnet
+ACCOUNT_NAME=test-campaign-8.testnet
 near create-account $ACCOUNT_NAME  --useFaucet
 ```
 
@@ -16,20 +16,44 @@ near deploy $ACCOUNT_NAME  ./target/near/test_campaign.wasm
 
 ```bash
 {
+    "data": [
+        {
+            "agent": "ai-creator.near/term-resolver/latest",
+            "env_vars": null,
+            "max_iterations": null,
+            "message": "{"index":0,"terms":"Bitcoin is above 60,
+            000 USD on August 28,
+            2025"}",
+            "referral_id": null,
+            "request_id": null,
+            "signer_id": "ai-creator.near",
+            "thread_id": null
+        }
+    ],
+    "event": "run_agent",
+    "standard": "nearai",
+    "version": "0.1.0"
+}
+```
+
+## According to Nearai
+
+```bash
+{
+  "standard": "nearai",
+  "version": "0.1.0",
+  "event": "run_agent",
   "data": [
     {
-      "agent": "Test bet at 2025-08-29T21:32:59.388Z",
-      "env_vars": null,
+      "message": "Transformer",
+      "agent": "zavodil.near/what-beats-rock/latest",
       "max_iterations": null,
-      "message": "ai-creator.near/term-resolver/latest",
+      "thread_id": null,
+      "env_vars": null,
+      "signer_id": "v01.ai-is-near.near",
       "referral_id": null,
-      "request_id": null,
-      "signer_id": "test-account3.testnet",
-      "thread_id": null
+      "amount": "0"
     }
-  ],
-  "event": "run_agent",
-  "standard": "nearai",
-  "version": "0.1.0"
+  ]
 }
 ```

--- a/contracts/test-campaign/src/events.rs
+++ b/contracts/test-campaign/src/events.rs
@@ -1,11 +1,11 @@
 use near_sdk::{env, log};
 use near_sdk::serde::Serialize;
-use near_sdk::serde_json::json;
+use near_sdk::serde_json::{json, Value};
 
 #[derive(Serialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct AgentData<'a> {
-    pub message: &'a str,
+    pub message: Value,
     pub agent: &'a str,
     pub env_vars: Option<&'a str>,
     pub request_id: Option<&'a str>,
@@ -23,15 +23,15 @@ pub struct AgentData<'a> {
 pub fn log_event<T: Serialize>(event: &str, data: T) {
     let event = json!({
         "standard": "nearai",
-        "version": "0.1.0",
+        "version": "0.1.19",
         "event": event,
         "data": [data],
     });
 
-    log!("EVENT_JSON:{}", event.to_string());
+    log!("{}", event.to_string());
 }
 
-pub fn run_agent(message: &str, agent: &str) {
+pub fn run_agent(message: Value, agent: &str) {
     log_event(
         "run_agent",
         AgentData {

--- a/contracts/test-campaign/src/events.rs
+++ b/contracts/test-campaign/src/events.rs
@@ -11,7 +11,6 @@ pub struct AgentData<'a> {
     pub request_id: Option<&'a str>,
     pub max_iterations: Option<u8>,
     pub thread_id: Option<&'a str>,
-    bet_id: u32,
     pub signer_id: &'a str,
     pub referral_id: Option<&'a str>,
 
@@ -28,16 +27,15 @@ pub fn log_event<T: Serialize>(event: &str, data: T) {
         "data": [data],
     });
 
-    log!("{}", event.to_string());
+    log!("EVENT_JSON:{}", event.to_string());
 }
 
-pub fn run_agent(message: &str, agent: &str, bet_id: u32) {
+pub fn run_agent(message: &str, agent: &str) {
     log_event(
         "run_agent",
         AgentData {
             message,
             agent,
-            bet_id: bet_id,
             env_vars: None,
             request_id: None,
             max_iterations: None,

--- a/contracts/test-campaign/src/events.rs
+++ b/contracts/test-campaign/src/events.rs
@@ -5,13 +5,13 @@ use near_sdk::serde_json::{json, Value};
 #[derive(Serialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct AgentData<'a> {
-    pub message: Value,
+    pub message: &'a str,
     pub agent: &'a str,
     pub env_vars: Option<&'a str>,
     pub request_id: Option<&'a str>,
     pub max_iterations: Option<u8>,
     pub thread_id: Option<&'a str>,
-
+    bet_id: u32,
     pub signer_id: &'a str,
     pub referral_id: Option<&'a str>,
 
@@ -31,12 +31,13 @@ pub fn log_event<T: Serialize>(event: &str, data: T) {
     log!("{}", event.to_string());
 }
 
-pub fn run_agent(message: Value, agent: &str) {
+pub fn run_agent(message: &str, agent: &str, bet_id: u32) {
     log_event(
         "run_agent",
         AgentData {
             message,
             agent,
+            bet_id: bet_id,
             env_vars: None,
             request_id: None,
             max_iterations: None,

--- a/contracts/test-campaign/src/lib.rs
+++ b/contracts/test-campaign/src/lib.rs
@@ -69,7 +69,7 @@ impl BetTermStorage {
     pub fn update_bet(&mut self, index: u32, resolution: String) {
         let caller = env::predecessor_account_id();
 
-        require!(caller.as_str() == "term-resolver.testnet", "Only resolver can update");
+        require!(caller.as_str() == "term-resolver.near", "Only resolver can update");
 
         let mut bet = self.bets.get(index).expect("No bet at index").clone();
         bet.resolution = resolution;

--- a/contracts/test-campaign/src/lib.rs
+++ b/contracts/test-campaign/src/lib.rs
@@ -2,6 +2,7 @@
 use near_sdk::{near, AccountId, env, require};
 use near_sdk::store::Vector;
 use near_sdk::json_types::U64;
+use near_sdk::serde_json::json;
 // use near_sdk::test_utils::{VMContextBuilder, get_logs};
 mod events;
 use crate::events::run_agent;
@@ -52,8 +53,13 @@ impl BetTermStorage {
     pub fn request_resolve(self, index: u32) {
         let bet = self.bets.get(index);
 
+         let payload = json!({
+            "index": index,
+            "terms": bet.unwrap().terms, 
+        }).to_string();
+
         run_agent(
-            &bet.unwrap().terms, // message
+            &payload, // message
             &"ai-creator.near/term-resolver/latest".to_string(), // agent  
         );
     }

--- a/contracts/test-campaign/src/lib.rs
+++ b/contracts/test-campaign/src/lib.rs
@@ -2,8 +2,13 @@
 use near_sdk::{near, AccountId, env, require};
 use near_sdk::store::Vector;
 use near_sdk::json_types::U64;
-use near_sdk::serde_json::json;
+use near_sdk::serde_json::{json, Value};
+
+// test imports
+// use near_sdk::testing_env;
 // use near_sdk::test_utils::{VMContextBuilder, get_logs};
+
+
 mod events;
 use crate::events::run_agent;
 
@@ -52,11 +57,11 @@ impl BetTermStorage {
     /// which can be picked up by an off-chain AI agent.
     pub fn request_resolve(&self, index: u32) {
         let bet = self.bets.get(index);
-
+        
+        let message = format!("{}_{}", bet.unwrap().terms, index); 
         run_agent(
-            &bet.unwrap().terms, // message
+            &message.to_string(), // message
             &"ai-creator.near/term-resolver/latest".to_string(), // agent
-            index  
         );
     }
 
@@ -149,51 +154,39 @@ mod tests {
     }
 
     #[test]
-    fn update_bet_sets_resolution() {
-        let mut contract = BetTermStorage::default();
-
-        // Arrange
-        let terms = make_bet(1);
-        contract.add_bet(terms.clone());
-        assert_eq!(contract.total_bets(), 1);
-
-        // Act
-        contract.update_bet(0, "TRUE".to_string());
-
-        // Assert
-        let b = contract.get_bet(0).expect("bet should exist");
-        assert_eq!(b.resolution, "TRUE");
-    }
-
-    #[test]
-    fn request_resolve_emits_event() {
-        // Arrange: set predecessor so the contract can include it in the event
+    fn request_resolve_emits_event_and_we_can_read_it() {
+        // set a predecessor so signer_id is populated
         let mut ctx = VMContextBuilder::new();
         ctx.predecessor_account_id("alice.near".parse().unwrap());
         testing_env!(ctx.build());
 
-        let mut contract = BetTermStorage::default();
-        let terms = "Kolkata Night Riders vs Rajasthan Royals results 4th May".to_string();
-        contract.add_bet(terms.clone());
+        let mut c = BetTermStorage::default();
+        c.add_bet("foo-term".to_string());
 
-        // Act
-        contract.request_resolve(0);
+        // act
+        c.request_resolve(0);
 
-        // Assert: exactly one log with the expected shape and fields
+        // read logs
         let logs = get_logs();
-        assert_eq!(logs.len(), 1, "expected exactly one event log");
+        println!("logs:\n{}", logs.join("\n"));
 
-        let v: serde_json::Value = serde_json::from_str(&logs[0]).expect("valid JSON log");
-        assert_eq!(v["standard"], "nearai");
-        assert_eq!(v["version"], "0.1.0");
+        assert_eq!(logs.len(), 1, "expected one event log");
+
+        
+        // inspect JSON
+        let v: Value = serde_json::from_str(&logs[0]).expect("valid JSON log");
         assert_eq!(v["event"], "run_agent");
-
-        // data[0]
+        assert_eq!(v["standard"], "nearai");
+        assert_eq!(v["version"], "0.1.19"); // match your current version
         let d0 = &v["data"][0];
-        assert_eq!(d0["message"], terms);
         assert_eq!(d0["agent"], "ai-creator.near/term-resolver/latest");
         assert_eq!(d0["signer_id"], "alice.near");
-        assert_eq!(d0["amount"], "0");
+
+        // if your message is "terms_index" per format!:
+        assert_eq!(d0["message"], "foo-term_0");
+
+        // if you also include bet_id in the event, you can assert it too:
+        // assert_eq!(d0["bet_id"], 0);
     }
 }
 

--- a/contracts/test-campaign/src/lib.rs
+++ b/contracts/test-campaign/src/lib.rs
@@ -5,8 +5,8 @@ use near_sdk::json_types::U64;
 use near_sdk::serde_json::{json, Value};
 
 // test imports
-use near_sdk::testing_env;
-use near_sdk::test_utils::{VMContextBuilder, get_logs};
+// use near_sdk::testing_env;
+// use near_sdk::test_utils::{VMContextBuilder, get_logs};
 
 
 mod events;

--- a/contracts/test-campaign/src/lib.rs
+++ b/contracts/test-campaign/src/lib.rs
@@ -53,14 +53,10 @@ impl BetTermStorage {
     pub fn request_resolve(&self, index: u32) {
         let bet = self.bets.get(index);
 
-         let payload = json!({
-            "index": index,
-            "terms": bet.unwrap().terms, 
-        });
-
         run_agent(
-            payload, // message
-            &"ai-creator.near/term-resolver/latest".to_string(), // agent  
+            &bet.unwrap().terms, // message
+            &"ai-creator.near/term-resolver/latest".to_string(), // agent
+            index  
         );
     }
 

--- a/contracts/test-campaign/src/lib.rs
+++ b/contracts/test-campaign/src/lib.rs
@@ -50,16 +50,16 @@ impl BetTermStorage {
     /// User-facing function to trigger resolution.
     /// This does NOT resolve on-chain, but instead emits a JSON log event
     /// which can be picked up by an off-chain AI agent.
-    pub fn request_resolve(self, index: u32) {
+    pub fn request_resolve(&self, index: u32) {
         let bet = self.bets.get(index);
 
          let payload = json!({
             "index": index,
             "terms": bet.unwrap().terms, 
-        }).to_string();
+        });
 
         run_agent(
-            &payload, // message
+            payload, // message
             &"ai-creator.near/term-resolver/latest".to_string(), // agent  
         );
     }

--- a/shade-agent-template/src/lib/near/functions.ts
+++ b/shade-agent-template/src/lib/near/functions.ts
@@ -51,6 +51,8 @@ export async function callFunction<T = unknown>(params: {
     waitUntil: params.waitUntil ?? "FINAL",
   });
 
+  console.log(outcome);
+  
   // If method returns a JSON, it will be in outcome.result
   // (The modular SDK normalizes this—no need to base64 decode.)
   return (outcome as unknown) as T;

--- a/shade-agent-template/src/scripts/TestCampaign.ts
+++ b/shade-agent-template/src/scripts/TestCampaign.ts
@@ -11,7 +11,7 @@ type Bet = {
   resolution: string;
 };
 
-const CONTRACT_ID = "test-campaign-7.testnet";
+const CONTRACT_ID = "test-campaign-8.testnet";
 if (!CONTRACT_ID) throw new Error("Set CONTRACT_ID in .env");
 
 async function runAll() {

--- a/shade-agent-template/src/scripts/TestCampaign.ts
+++ b/shade-agent-template/src/scripts/TestCampaign.ts
@@ -11,12 +11,12 @@ type Bet = {
   resolution: string;
 };
 
-const CONTRACT_ID = "test-campaign-15.testnet";
+const CONTRACT_ID = "test-campaign-16.testnet";
 if (!CONTRACT_ID) throw new Error("Set CONTRACT_ID in .env");
 
 async function runAll() {
   // 1) add_bet(terms: String)
-  const terms = `Test bet at ${new Date().toISOString()}`;
+  const terms = `Bitcoin is above 60,000 USD on August 28, 2025`;
   console.log("1) add_bet ->", terms);
   await callFunction({
     contractId: CONTRACT_ID,

--- a/shade-agent-template/src/scripts/TestCampaign.ts
+++ b/shade-agent-template/src/scripts/TestCampaign.ts
@@ -11,7 +11,7 @@ type Bet = {
   resolution: string;
 };
 
-const CONTRACT_ID = "test-campaign-8.testnet";
+const CONTRACT_ID = "test-campaign-9.testnet";
 if (!CONTRACT_ID) throw new Error("Set CONTRACT_ID in .env");
 
 async function runAll() {

--- a/shade-agent-template/src/scripts/TestCampaign.ts
+++ b/shade-agent-template/src/scripts/TestCampaign.ts
@@ -11,7 +11,7 @@ type Bet = {
   resolution: string;
 };
 
-const CONTRACT_ID = "test-campaign-9.testnet";
+const CONTRACT_ID = "test-campaign-15.testnet";
 if (!CONTRACT_ID) throw new Error("Set CONTRACT_ID in .env");
 
 async function runAll() {

--- a/shade-agent-template/src/scripts/TestCampaign.ts
+++ b/shade-agent-template/src/scripts/TestCampaign.ts
@@ -11,7 +11,7 @@ type Bet = {
   resolution: string;
 };
 
-const CONTRACT_ID = "test-campaign-5.testnet";
+const CONTRACT_ID = "test-campaign-7.testnet";
 if (!CONTRACT_ID) throw new Error("Set CONTRACT_ID in .env");
 
 async function runAll() {


### PR DESCRIPTION
Serialize {index, terms} via serde_json::json and pass to run_agent

Change signature to &self (avoid consuming contract)

Add expect("No bet at index") guard

Import near_sdk::serde_json::json

Enable agent to parse index and call update_bet deterministically without extra lookup