### PR TITLE
Refactor getTransactionsForAddress to support multi-chain Etherscan (fixes #69)

### DIFF
--- a/shade-agent-template/src/bets/config.ts
+++ b/shade-agent-template/src/bets/config.ts
@@ -1,3 +1,4 @@
+import { networkId } from "../lib/chain-signatures";
 
 // BOT CONFIGURATIONS
 export const BOT_NAME = process.env.BOT_NAME || "smol_bet";
@@ -13,6 +14,12 @@ export const POLLING_INTERVAL = 5 * 60 * 1000; // 5 minutes between search polls
 
 export const BASESCAN_API = (networkId: string) =>
   `https://api${networkId === "testnet" ? "-sepolia" : ""}.basescan.org/api`;
+
+export const ETHERSCAN_API = process.env.ETHERSCAN_API || "";
+
+export const PUBLIC_CONTRACT_ID = process.env.NEXT_PUBLIC_contractId!;
+
+export const CHAIN_ID = (networkId == "mainnet") ? 8453 : 84532;
 
 export const FAKE_REPLY = process.env.FAKE_REPLY === "true";
 export const SEARCH_ONLY = process.env.SEARCH_ONLY === "true";

--- a/shade-agent-template/src/bets/handlers/deposits.ts
+++ b/shade-agent-template/src/bets/handlers/deposits.ts
@@ -5,6 +5,8 @@ import {
   DEPOSIT_PROCESSING_DELAY,
   MAX_DEPOSIT_ATTEMPTS,
   BOT_NAME,
+  CHAIN_ID,
+  PUBLIC_CONTRACT_ID,
 } from "../config";
 import {
   pendingDeposits,
@@ -47,13 +49,13 @@ export async function processDeposits(): Promise<void> {
 
         log.info(balance1 >= bet.stake);
         log.info(balance2 >= bet.stake);
-        let tx = await getTransactionsForAddress(bet.authorDepositAddress);
+        let tx = await getTransactionsForAddress(bet.authorDepositAddress, CHAIN_ID);
 
         console.log(tx);
         
         const creatorAddress = tx?.from;
 
-        tx = await getTransactionsForAddress(bet.opponentDepositAddress);
+        tx = await getTransactionsForAddress(bet.opponentDepositAddress, CHAIN_ID);
         const opponentAddress = tx?.from;
 
         if (creatorAddress && opponentAddress) {
@@ -75,11 +77,7 @@ export async function processDeposits(): Promise<void> {
 
     const betPath = `${bet.creatorUsername}-${bet.opponentUsername}-${bet.id}`;
     const { address: resolverAddress } = await generateAddress({
-      publicKey:
-        networkId === "testnet"
-          ? process.env.MPC_PUBLIC_KEY_TESTNET
-          : process.env.MPC_PUBLIC_KEY_MAINNET,
-      accountId: process.env.NEXT_PUBLIC_contractId!,
+      accountId: PUBLIC_CONTRACT_ID,
       path: betPath,
       chain: "evm",
     });

--- a/shade-agent-template/src/bets/handlers/replies.ts
+++ b/shade-agent-template/src/bets/handlers/replies.ts
@@ -1,6 +1,7 @@
 import { evm } from "../../utils/evm";
 import { sleep } from "../../utils/utils";
 import {
+  PUBLIC_CONTRACT_ID,
   REPLY_PROCESSING_DELAY,
 } from "../config";
 import {
@@ -9,7 +10,7 @@ import {
 } from "../state";
 import { xPost } from "../../lib/X/endpoints/xPost";
 import { parsePostToBet } from "../lib/nearai";
-import { generateAddress, networkId } from "../../lib/chain-signatures";
+import { generateAddress } from "../../lib/chain-signatures";
 import { log } from "../lib/log";
 
 export async function processReplies(): Promise<void> {
@@ -59,7 +60,7 @@ export async function processReplies(): Promise<void> {
 
     const authorBetPath = `${post.author_username}-${post.id}`;
     const { address: authorDepositAddress } = await generateAddress({
-      accountId: process.env.NEXT_PUBLIC_contractId!,
+      accountId: PUBLIC_CONTRACT_ID,
       path: authorBetPath,
       chain: "evm",
     });
@@ -68,7 +69,7 @@ export async function processReplies(): Promise<void> {
 
     const opponentBetPath = `${opponentUsername}-${post.id}`;
     const { address: opponentDepositAddress } = await generateAddress({
-      accountId: process.env.NEXT_PUBLIC_contractId!,
+      accountId: PUBLIC_CONTRACT_ID,
       path: opponentBetPath,
       chain: "evm",
     });

--- a/shade-agent-template/src/bets/services/explorer.ts
+++ b/shade-agent-template/src/bets/services/explorer.ts
@@ -1,20 +1,25 @@
-import { networkId } from "@neardefi/shade-agent-js";
-import { BASESCAN_API } from "../config";
 import { fetchJson } from "../../utils/utils";
+import { ETHERSCAN_API } from "../config";
 
 export async function getTransactionsForAddress(
   address: string,
+  chainId: number,
   action: "txlist" | "tokentx" = "txlist"
 ) {
   try {
-    const url = `${BASESCAN_API(networkId)}?module=account&action=${action}&address=${address}` +
-      `&startblock=0&endblock=latest&page=1&offset=10&sort=asc&apikey=${process.env.BASE_API_KEY}`;
+    const url = `https://api.etherscan.io/v2/api?chainid=${chainId}` +
+      `&module=account&action=${action}&address=${address}` +
+      `&startblock=0&endblock=latest&page=1&offset=10&sort=asc&apikey=${ETHERSCAN_API}`;
+
     const res = await fetchJson(url);
+    console.log(res);
+    
     const tx = res?.result?.[0];
+
     if (!tx || tx?.isError === "1" || !tx?.from) return undefined;
     return tx;
   } catch (e) {
-    console.log(e);
+    console.log("Error fetching transactions:", e);
     return undefined;
   }
 }


### PR DESCRIPTION
…2 API(fixes #69)

- Replaced old BASESCAN_API(networkId) endpoint with universal https://api.etherscan.io/v2/api
- Added chainId parameter to allow querying transactions across multiple supported chains
- Preserved support for txlist and tokentx actions
- Improved flexibility for adding new chains with a single API key
- Maintained error handling to return undefined on invalid or failed responses