### PR TITLE
Added script to request and resolve bets created(fixes #105)

### DIFF
--- a/shade-agent-template/src/scripts/ResolveTerms.ts
+++ b/shade-agent-template/src/scripts/ResolveTerms.ts
@@ -1,0 +1,111 @@
+// ResolveAllBets.ts
+import { resolveBetWithAI } from "../bets/lib/nearai";
+import { callFunction, viewFunction } from "../lib/near/functions";
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: ".env.development.local" });
+
+// Matches your Rust struct
+type Bet = {
+  bet_id: number; // u64 but small; OK as number here
+  terms: string;
+  resolution: string; // "" or one of "TRUE" | "FALSE" | "INVALID"
+};
+
+// ── config ────────────────────────────────────────────────────────────────────
+const CONTRACT_ID = "test-campaign.near";
+if (!CONTRACT_ID) throw new Error("Set CONTRACT_ID");
+
+// Swap this with your real oracle/agent decision.
+async function decideResolution(bet: Bet) {
+  // Demo placeholder logic
+  const resolution = await resolveBetWithAI(bet.terms);
+  
+  if (resolution.includes("TRUE")) return "TRUE";
+  if (resolution.includes("FALSE")) return "FALSE";
+  return "INVALID";
+}
+
+async function runAll() {
+  console.log("Smol Bet — Resolve All Bets (sequential)\n");
+
+  // 1) total_bets() -> u32
+  console.log("1) total_bets");
+  const total = await viewFunction<number>({
+    contractId: CONTRACT_ID,
+    methodName: "total_bets",
+  });
+  console.log("   total:", total);
+
+  if (!total || total <= 0) {
+    console.log("\nNo bets to process. ✅");
+    return;
+  }
+
+  // 2) Iterate 0..total-1 and resolve each one
+  for (let index = 0; index < total; index++) {
+    console.log(`\n[${index + 1}/${total}] get_bet(index=${index})`);
+    const bet = await viewFunction<Bet | null>({
+      contractId: CONTRACT_ID,
+      methodName: "get_bet",
+      args: { index },
+    });
+
+    console.log(bet);
+
+    if (!bet) {
+      console.log("   • no bet at this index — skipping");
+      continue;
+    }
+
+    // Already resolved? skip
+    if (bet.resolution && bet.resolution.length > 0) {
+      console.log(`   • already resolved: ${bet.resolution} — skipping`);
+      continue;
+    }
+
+    console.log("   • terms:", bet.terms);
+
+    // 3) request_resolve(index: u32)
+    console.log(`   • request_resolve(index=${index})`);
+    await callFunction({
+      contractId: CONTRACT_ID,
+      methodName: "request_resolve",
+      args: { index },
+      gasTGas: 15,
+      waitUntil: "FINAL",
+    });
+    console.log("     ✓ resolve event emitted (check logs/indexer)");
+
+    
+    // 4) decide outcome (replace with your oracle/agent)
+    const resolution = await decideResolution(bet);
+    console.log("   • decided resolution:", resolution);
+
+    // 5) update_bet(index: u32, resolution: String)
+    console.log(`   • update_bet(index=${index}, resolution="${resolution}")`);
+    await callFunction({
+      contractId: CONTRACT_ID,
+      methodName: "update_bet",
+      args: { index, resolution },
+      gasTGas: 30,
+      waitUntil: "FINAL",
+    });
+    console.log("     ✓ bet updated on-chain");
+
+    // 6) verify
+    const after = await viewFunction<Bet | null>({
+      contractId: CONTRACT_ID,
+      methodName: "get_bet",
+      args: { index },
+    });
+    console.log("   • verify:", after);
+  }
+
+  console.log("\n✅ Done. All bets processed.");
+}
+
+runAll().catch((e) => {
+  console.error("❌ Error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
feat: add ResolveAllBets.ts script to sequentially resolve all bets

This commit introduces a new standalone script, `ResolveAllBets.ts`, which provides an automated way to walk through every bet stored in the `test-campaign` contract and resolve them one by one.

- **Integration with existing utils** Reuses `callFunction` and `viewFunction` from `../lib/near/functions` for consistent interaction with the NEAR contract.

- **Environment configuration** Loads configuration from `.env.development.local` for contract IDs and account setup, matching the style of `TestCampaing.ts`.

- **Sequential resolution** Fetches the total number of bets via `total_bets`, iterates over each index, and processes them in order. Each transaction waits until `FINAL` before moving to the next to guarantee determinism and avoid nonce issues.

- **Resolution flow per bet**
  1. Skip bets that are already resolved.
  2. Emit a `request_resolve(index)` event (to support off-chain indexers).
  3. Decide resolution outcome using `decideResolution`, currently powered by a placeholder AI helper (`resolveBetWithAI`).
  4. Call `update_bet(index, resolution)` to finalize the outcome on-chain.
  5. Verify the update by fetching the bet again.

- **Logging & safety** Logs progress for each step, including verification of updates. Skips missing bets or already resolved bets safely, so the script can be re-run without breaking consistency.

This script makes it possible to:
- Batch-process and resolve all outstanding bets in a predictable way.
- Integrate AI- or oracle-based resolution logic without touching core contract code.
- Run it repeatedly without risk of double-resolving bets.

- Add env/config option (`RESUME_FROM`) to resume from a specific index if the script halts mid-run.
- Add smarter auto-resume logic to detect the first unresolved bet.
- Replace placeholder AI decision logic with production-grade oracle/agent integration.